### PR TITLE
Change the size of metaCopyright column  

### DIFF
--- a/pH7CMSLangs.sql
+++ b/pH7CMSLangs.sql
@@ -8,6 +8,7 @@
 -- Package:       PH7 / Internationalize / Sql
 --
 --
+ALTER TABLE  `pH7_MetaMain` CHANGE  `headline`  `headline` VARCHAR( 255 );
 
 INSERT INTO pH7_LanguagesInfo (langId, name, charset, active, direction, author, website, email) VALUES
 ('fr_FR', 'Français', 'UTF-8', '1', 'ltr', 'Pierre-Henry Soria', 'http://ph7.me', 'me@ph7.me'),

--- a/pH7CMSLangs.sql
+++ b/pH7CMSLangs.sql
@@ -8,7 +8,7 @@
 -- Package:       PH7 / Internationalize / Sql
 --
 --
-ALTER TABLE  `pH7_MetaMain` CHANGE  `headline`  `headline` VARCHAR( 255 );
+ALTER TABLE  `pH7_MetaMain` CHANGE  `metaCopyright`  `metaCopyright` VARCHAR( 255 );
 
 INSERT INTO pH7_LanguagesInfo (langId, name, charset, active, direction, author, website, email) VALUES
 ('fr_FR', 'Français', 'UTF-8', '1', 'ltr', 'Pierre-Henry Soria', 'http://ph7.me', 'me@ph7.me'),


### PR DESCRIPTION
The current size of metaCopyright field in MetaMain table is too small to accept the text for other languages that you are using in the insert into statement