### PR TITLE
Enable support for Progressive Web App

### DIFF
--- a/_protected/app/configs/routes/fr.xml
+++ b/_protected/app/configs/routes/fr.xml
@@ -6,6 +6,9 @@
 
     <!-- BEGIN SYSTEM MODULES -->
 
+    <!-- Progressive Web App (PWA) -->
+      <route url="manifest\.json" path="system/modules" module="pwa" controller="main" action="manifest" />
+
     <!-- User -->
       <route url="@([a-zA-Z0-9_-]+)" path="system/modules" module="user" controller="profile" action="index" vars="username" />
       <route url="inscription" path="system/modules" module="user" controller="signup" action="step1" />


### PR DESCRIPTION
Works only if the PWA module is enabled and if your website is running under https.
This is for https://github.com/pH7Software/pH7-Social-Dating-CMS/pull/363